### PR TITLE
fix: add cloudflare account id

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -94,6 +94,7 @@ jobs:
         run: make deploy-prd-wrangler
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   deploy-extension:
     needs: [build-project, deploy-backend]


### PR DESCRIPTION
There was an error deploying my code to cloudflare worker despite having the CLOUDFLARE_API_TOKEN env, turns out I have to add my CLOUDFLARE_ACCOUNT_ID env aswell.
<img width="905" height="382" alt="image" src="https://github.com/user-attachments/assets/6d964983-b64c-4d7c-86e2-a189ef8dc734" />

ref to the fix [here](https://github.com/cloudflare/workers-sdk/issues/8230)