### PR TITLE
fix: firefox specific manifest

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -6,7 +6,11 @@
     "browser_specific_settings": {
         "gecko": {
             "id": "schedulr@mmuschedulr.com",
-            "strict_min_version": "109.0"
+            "strict_min_version": "109.0",
+            "data_collection_permissions": {
+                "required": ["authenticationInfo", "websiteContent", "personallyIdentifyingInfo"],
+                "optional": ["technicalAndInteraction"]
+            }
         }
     },
     "icons": {


### PR DESCRIPTION
firefox desktop 140 and later require dev to put data collection permissions in manifest so I'm adding that